### PR TITLE
Fix OnceCell compilation issues.

### DIFF
--- a/src/rpc/raw.rs
+++ b/src/rpc/raw.rs
@@ -2,7 +2,7 @@ use iced_x86::{code_asm::*, IcedError};
 
 use std::{
     any::{self, TypeId},
-    cell::OnceCell,
+    lazy::OnceCell,
     cmp, fmt, io, mem, slice,
 };
 

--- a/src/syringe.rs
+++ b/src/syringe.rs
@@ -2,7 +2,7 @@ use cstr::cstr;
 use iced_x86::{code_asm::*, IcedError};
 use num_enum::TryFromPrimitive;
 use path_absolutize::Absolutize;
-use std::{cell::OnceCell, io, mem, path::Path};
+use std::{lazy::OnceCell, io, mem, path::Path};
 use u16cstr::u16cstr;
 use widestring::U16CString;
 use winapi::shared::{


### PR DESCRIPTION
I didn't find oncecell in the std library, should I replace it with lazy?