### PR TITLE
Bump sysinfo for ntapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["dll-injection", "dll", "injector", "windows", "rpc"]
 [dependencies]
 winapi = { version = "0.3", features = ["processthreadsapi", "libloaderapi", "memoryapi", "wow64apiset"], default-features = false }
 cstr = { version = "0.2", default-features = false }
-sysinfo = { version = "0.24", default-features = false }
+sysinfo = { version = "0.26", default-features = false }
 widestring = { version = "1.0", features = ["std", "alloc"], default-features = false }
 path-absolutize = { version = "3.0", default-features = false }
 stopwatch = { version = "0.0", default-features = false }


### PR DESCRIPTION
`dll-syringe` contains a transitive dependency to `ntapi 0.3.7`:

```
> cargo tree -i ntapi
ntapi v0.3.7
└── sysinfo v0.24.5
    └── dll-syringe v0.13.1
```

During compilation, a warning is reported:

```
warning: the following packages contain code that will be rejected by a future version of Rust: ntapi v0.3.7
```

Bumping `sysinfo` to `0.26` fixes the warning.