### PR TITLE
Enabling Testing and Running dll-syringe on WINE

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = ['i686-pc-windows-msvc','x86_64-pc-windows-msvc']

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 Cargo.lock
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "rust-analyzer.checkOnSave.command": "clippy",
+    "[rust]": {
+        "editor.formatOnSave": true
+    },
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "tests/helpers/test_payload/Cargo.toml",
+        "tests/helpers/test_target/Cargo.toml",
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test on Windows",
+      "type": "shell",
+      "command": "pwsh ./scripts/test.ps1",
+    },
+    {
+      "label": "Clean",
+      "type": "shell",
+      "command": "pwsh ./scripts/clean.ps1",
+    },
+    {
+      "label": "Test on Wine (See Readme)",
+      "type": "shell",
+      "command": "pwsh ./scripts/test-wine.ps1",
+    },
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,16 +5,19 @@
       "label": "Test on Windows",
       "type": "shell",
       "command": "pwsh ./scripts/test.ps1",
+      "problemMatcher": []
     },
     {
       "label": "Clean",
       "type": "shell",
       "command": "pwsh ./scripts/clean.ps1",
+      "problemMatcher": []
     },
     {
       "label": "Test on Wine (See Readme)",
       "type": "shell",
       "command": "pwsh ./scripts/test-wine.ps1",
+      "problemMatcher": []
     },
   ]
 }

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ syringe.eject(injected_payload).unwrap();
 ## Remote Procedure Calls (RPC)
 This crate supports two mechanisms for rpc. Both only work one-way for calling exported functions in the target process and are only intended for one-time initialization usage. For extended communication a dedicated rpc library should be used.
 
-|                  | `RemotePayloadProcedure`        | `RemoteRawProcedure` |
-| ---------------- | ------------------------------ | ------------------------------------------ |
-| Feature | `rpc-payload` | `rpc-raw` |
-| Argument and Return Requirements | `Serialize + DeserializeOwned` | `Copy`, Argument size has to be smaller than `usize` in target process |
-| Function Definition       | Using macro `payload_procedure!` | Any `extern "system"` or `extern "C"` with `#[no_mangle]` |
+|                                  | `RemotePayloadProcedure`         | `RemoteRawProcedure`                                                   |
+| -------------------------------- | -------------------------------- | ---------------------------------------------------------------------- |
+| Feature                          | `rpc-payload`                    | `rpc-raw`                                                              |
+| Argument and Return Requirements | `Serialize + DeserializeOwned`   | `Copy`, Argument size has to be smaller than `usize` in target process |
+| Function Definition              | Using macro `payload_procedure!` | Any `extern "system"` or `extern "C"` with `#[no_mangle]`              |
 
 ### RemotePayloadProcedure
 A rpc mechanism based on [`bincode`](https://crates.io/crates/bincode).
@@ -119,6 +119,36 @@ syringe.eject(injected_payload).unwrap();
 ## License
 Licensed under MIT license ([LICENSE](https://github.com/OpenByteDev/dll-syringe/blob/master/LICENSE) or http://opensource.org/licenses/MIT)
 
+## Instructions for Contributors
+
+### Prerequisites
+
+You will need the nightly toolchains of Rust and Cargo to build/test this project.
+
+```
+rustup target add x86_64-pc-windows-msvc --toolchain nightly
+rustup target add i686-pc-windows-msvc --toolchain nightly
+```
+
+> [!NOTE]
+> Also applies to developing on Linux, you'll need it for your IDE (i.e. rust-analyzer or RustRover) to work properly.
+
+### Run Tests
+
+Run the `./scripts/test.ps1` script from PowerShell.
+
+### Running Tests on Linux
+
+You'll need `cargo xwin` to build the MSVC targets on Linux:
+
+```
+cargo install cargo-xwin
+```
+
+After that, you can run the tests with `./scripts/test-wine.ps1` PowerShell script.
+(As opposed to `./scripts/test.ps1`)
+
+Make sure you have Wine installed!
+
 ## Attribution
 Inspired by [Reloaded.Injector](https://github.com/Reloaded-Project/Reloaded.Injector) from [Sewer](https://github.com/Sewer56).
- 

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,9 +1,0 @@
-cargo clean
-
-Set-Location .\tests\helpers\test_payload
-cargo clean
-Set-Location ..\..\..
-
-Set-Location .\tests\helpers\test_target
-cargo clean
-Set-Location ..\..\..

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,0 +1,11 @@
+# Navigate up one folder from the current script location
+Set-Location "$PSScriptRoot\.."
+cargo clean
+
+Set-Location "./tests/helpers/test_payload"
+cargo clean
+Set-Location "../../.."
+
+Set-Location "./tests/helpers/test_target"
+cargo clean
+Set-Location "../../.."

--- a/scripts/test-wine.ps1
+++ b/scripts/test-wine.ps1
@@ -1,0 +1,17 @@
+# Navigate up one folder from the current script location
+Set-Location "$PSScriptRoot\.."
+
+# Testing
+$env:CROSS_SYSROOT = "." # pretend we cross
+
+# Prebuild dummy projects.
+cargo +nightly xwin rustc --manifest-path "tests/helpers/test_target/Cargo.toml" --target i686-pc-windows-msvc --xwin-arch x86 --xwin-cache-dir "target/cache/x86"
+cargo +nightly xwin rustc --manifest-path "tests/helpers/test_payload/Cargo.toml" --target i686-pc-windows-msvc --xwin-arch x86 --xwin-cache-dir "target/cache/x86"
+cargo +nightly xwin rustc --manifest-path "tests/helpers/test_target/Cargo.toml" --target x86_64-pc-windows-msvc --xwin-arch x86_64 --xwin-cache-dir "target/cache/x64"
+cargo +nightly xwin rustc --manifest-path "tests/helpers/test_payload/Cargo.toml" --target x86_64-pc-windows-msvc --xwin-arch x86_64 --xwin-cache-dir "target/cache/x64"
+
+# Windows/MSVC x86
+cargo +nightly xwin test --target i686-pc-windows-msvc --xwin-arch x86 --xwin-cache-dir "target/cache/x86"
+
+# Windows/MSVC x64
+cargo +nightly xwin test --target x86_64-pc-windows-msvc --xwin-arch x86_64 --xwin-cache-dir "target/cache/x64"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,8 @@
+# Navigate up one folder from the current script location
+Set-Location "$PSScriptRoot\.."
+
+# Windows/MSVC x86
+cargo test --target i686-pc-windows-msvc -- --nocapture
+
+# Windows/MSVC x64
+cargo test --target x86_64-pc-windows-msvc -- --nocapture

--- a/src/process/memory/buffer.rs
+++ b/src/process/memory/buffer.rs
@@ -338,6 +338,12 @@ impl<'a> ProcessMemorySlice<'a> {
         }
 
         let mut bytes_written = 0;
+        if buf.is_empty() {
+            // This works around a discrepancy between Wine and actual Windows.
+            // On Wine, a 0 sized write fails, on Windows this suceeds. Will file as bug soon.
+            return Ok(());
+        }
+
         let result = unsafe {
             WriteProcessMemory(
                 self.process.as_raw_handle(),

--- a/test.ps1
+++ b/test.ps1
@@ -1,2 +1,0 @@
-cargo test --target i686-pc-windows-msvc -- --nocapture
-cargo test --target x86_64-pc-windows-msvc -- --nocapture

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -87,7 +87,7 @@ pub fn build_helper_crate(
 ///
 /// So as a compromise, we build the test binaries outside for testing from Linux.
 fn is_cross() -> bool {
-    return var("CROSS_SYSROOT").is_ok();
+    var("CROSS_SYSROOT").is_ok()
 }
 
 #[macro_export]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,8 +9,6 @@ use std::{
     sync::Mutex,
 };
 
-static mut RUST_INSTALL_LOCK: Mutex<i32> = Mutex::new(0);
-
 pub fn build_test_payload_x86() -> Result<PathBuf, Box<dyn Error>> {
     build_helper_crate("test_payload", &find_x86_variant_of_target(), false, "dll")
 }
@@ -55,7 +53,7 @@ pub fn build_helper_crate(
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
-    
+
         let exit_code = command.current_dir(&payload_crate_path).spawn()?.wait()?;
         assert!(
             exit_code.success(),
@@ -70,7 +68,11 @@ pub fn build_helper_crate(
     payload_artifact_path.push(target);
     payload_artifact_path.push(if release { "release" } else { "debug" });
     payload_artifact_path.push(format!("{crate_name}.{ext}"));
-    assert!(&payload_artifact_path.exists(), "Artifact doesn't exist! {:?}", &payload_artifact_path);
+    assert!(
+        &payload_artifact_path.exists(),
+        "Artifact doesn't exist! {:?}",
+        &payload_artifact_path
+    );
 
     Ok(payload_artifact_path)
 }


### PR DESCRIPTION
This PR takes some steps towards enabling library development from Linux, as well as testing against Wine for people gaming on non-Windows platforms.

- [X] Builds on Linux
- [X] IDE (at least rust-analyzer) functions correctly on non-Windows platforms
- [X] Readme has Instructions for Devs
- [X] Tests Run on Linux
  - [x] All Tests pass on Linux 
  
Currently tests fail on `WriteProcessMemory` to remote process on some RPC calls. 
Cause is unknown, this is a draft as I'm curiously looking into it. Printf debugging is tedious, but you gotta do what you gotta do.

Update: Failure cause was `WriteProcessMemory` with 0 length, seems Windows is happy with this, but Wine returns an error. Submitted as [Wine Bug #56357](https://bugs.winehq.org/show_bug.cgi?id=56357).

Update 2: Apparently the behaviour of this changed in Windows 10 and above, so this fix also fixes the library for Windows 8.1 and below.

Regarding implementation:
- We build with MSVC via [cargo-xwin](https://github.com/rust-cross/cargo-xwin)
- Tests are ran in Wine (`cargo` does this automatically for us).
- Running tests via [cross-rs](https://github.com/cross-rs/cross) is also supported.

Other changes:
- Moved scripts to `scripts` subfolder.
- Added a script for testing on Wine.
- Added some sane configuration settings for VSCode (e.g. auto rustfmt).
- Set toolchain as `nightly` by default using `rust-toolchain.toml`, for people who don't have theirs as nightly by default.

-------------------------------

Changes potentially coming in future PRs:
- [x] Support into Suspended Processes
- [x] C Bindings
- [x] .NET Bindings

