### PR TITLE
Added: Support for Injecting into Suspended Processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 A windows dll injection library written in Rust.
 
 ## Supported scenarios
+
+> [!WARNING]
+> Although tests currently pass, some uses of 64-bit into 32-bit may potentially fail on 
+> Linux (WINE) due to [Wine Bug #56362](https://bugs.winehq.org/show_bug.cgi?id=56362).
+
 | Injector Process | Target Process | Supported?                                 |
 | ---------------- | -------------- | ------------------------------------------ |
 | 32-bit           | 32-bit         | Yes                                        |

--- a/src/rpc/rpc_core.rs
+++ b/src/rpc/rpc_core.rs
@@ -1,5 +1,4 @@
-use iced_x86::{code_asm::*, IcedError};
-
+use iced_x86::code_asm::*;
 use std::{
     ffi::CString,
     mem,

--- a/src/syringe.rs
+++ b/src/syringe.rs
@@ -116,6 +116,28 @@ impl Syringe {
         }
     }
 
+    /// Creates a new syringe for the given suspended target process.
+    pub fn for_suspended_process(process: OwnedProcess) -> Result<Self, io::Error> {
+        let syringe = Self::for_process(process);
+
+        // If we are injecting into a 'suspended' process, then said process is said to not be fully
+        // initialized. This means:
+        // - We can't use `EnumProcessModulesEx` and friends.
+        // - So we can't locate Kernel32.dll in 32-bit process (from 64-bit process)
+        // - And therefore calling LoadLibrary is not possible.
+
+        // Thankfully we can 'initialize' this suspended process without running any end user logic
+        // (e.g. a game's entry point) by creating a dummy method and invoking it.
+        let ret = 0xC3;
+        let bx = syringe.remote_allocator.alloc_and_copy(&ret)?;
+        let mut dummy_param = 0;
+        syringe
+            .process()
+            .run_remote_thread(unsafe { mem::transmute(bx.as_raw_ptr()) }, &mut dummy_param)?;
+
+        Ok(syringe)
+    }
+
     /// Returns the target process for this syringe.
     pub fn process(&self) -> BorrowedProcess<'_> {
         self.remote_allocator.process()

--- a/src/syringe.rs
+++ b/src/syringe.rs
@@ -128,12 +128,12 @@ impl Syringe {
 
         // Thankfully we can 'initialize' this suspended process without running any end user logic
         // (e.g. a game's entry point) by creating a dummy method and invoking it.
-        let ret = 0xC3;
+        let ret: u8 = 0xC3;
         let bx = syringe.remote_allocator.alloc_and_copy(&ret)?;
-        let mut dummy_param = 0;
-        syringe
-            .process()
-            .run_remote_thread(unsafe { mem::transmute(bx.as_raw_ptr()) }, &mut dummy_param)?;
+        syringe.process().run_remote_thread(
+            unsafe { mem::transmute(bx.as_raw_ptr()) },
+            std::ptr::null::<u8>() as *mut u8,
+        )?;
 
         Ok(syringe)
     }

--- a/tests/eject.rs
+++ b/tests/eject.rs
@@ -10,7 +10,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let module = syringe.inject(payload_path).unwrap();
         syringe.eject(module).unwrap();
     }
@@ -21,7 +21,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let module = syringe.inject(payload_path).unwrap();
 
         syringe.process().kill().unwrap();

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -10,16 +10,16 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         syringe.inject(payload_path).unwrap();
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn inject_with_invalid_path_fails_with_remote_io(
         process: OwnedProcess,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let result = syringe.inject("invalid path");
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -37,7 +37,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         syringe.process().kill().unwrap();
 
         let result = syringe.inject(payload_path);

--- a/tests/module.rs
+++ b/tests/module.rs
@@ -33,7 +33,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let module = syringe.inject(payload_path).unwrap();
         assert!(module.guess_is_loaded());
     }
@@ -45,7 +45,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let module = syringe.inject(payload_path).unwrap();
         syringe.eject(module).unwrap();
         assert!(!module.try_guess_is_loaded().unwrap());
@@ -58,7 +58,7 @@ syringe_test! {
         process: OwnedProcess,
         payload_path: &Path,
     ) {
-        let syringe = Syringe::for_process(process);
+        let syringe = Syringe::for_suspended_process(process).unwrap();
         let module = syringe.inject(payload_path).unwrap();
         syringe.process().kill().unwrap();
         assert!(!module.try_guess_is_loaded().unwrap());

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -163,12 +163,17 @@ fn is_running_under_wine() -> bool {
     }
 }
 
+// winapi crate doesn't have this.
+// This is in ntdll, so already loaded for every Windows process.
+extern "system" {
+    fn RtlGetVersion(lpVersionInformation: &mut OSVERSIONINFOW) -> u32;
+}
+
 fn is_older_than_windows_10() -> bool {
     unsafe {
-        let version = GetVersion();
-        let major = (version & 0xFF) as u8;
-
-        // Windows 10 is version 10.0. Threshold for older versions is any major version less than 10.
-        major < 10
+        let mut os_info: OSVERSIONINFOW = zeroed();
+        os_info.dwOSVersionInfoSize = size_of::<OSVERSIONINFOW>() as u32;
+        RtlGetVersion(&mut os_info);
+        os_info.dwMajorVersion < 10
     }
 }

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,6 +1,10 @@
+use core::mem::{size_of, zeroed};
 use dll_syringe::process::{BorrowedProcess, OwnedProcess, Process};
-use winapi::um::{libloaderapi::{GetProcAddress, LoadLibraryA}, sysinfoapi::GetVersion};
-use std::{fs, mem, time::Duration, ffi::CString};
+use std::{ffi::CString, fs, mem, process::Command, time::Duration};
+use winapi::um::{
+    libloaderapi::{GetProcAddress, LoadLibraryA},
+    winnt::OSVERSIONINFOW,
+};
 
 #[allow(unused)]
 mod common;
@@ -29,7 +33,7 @@ process_test! {
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn list_module_handles_on_crashed_does_not_hang(
         process: OwnedProcess
     ) {
@@ -39,7 +43,7 @@ process_test! {
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn is_alive_is_true_for_running(
         process: OwnedProcess
     ) {
@@ -49,7 +53,7 @@ process_test! {
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn is_alive_is_false_for_killed(
         process: OwnedProcess
     ) {
@@ -77,7 +81,7 @@ process_test! {
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn kill_guard_kills_process_on_drop(
         process: OwnedProcess
     ) {
@@ -88,7 +92,7 @@ process_test! {
     }
 }
 
-process_test! {
+suspended_process_test! {
     fn long_process_paths_are_supported(
         process: OwnedProcess
     ) {

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,11 +9,11 @@ mod core {
     pub use super::*;
     use std::time::Duration;
 
-    process_test! {
+    suspended_process_test! {
         fn get_procedure_address_of_win32_fn(
             process: OwnedProcess,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
 
             let module = syringe.process().wait_for_module_by_name("kernel32.dll", Duration::from_secs(1)).unwrap().unwrap();
             let open_process = syringe.get_procedure_address(
@@ -29,7 +29,7 @@ mod core {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let dll_main = syringe.get_procedure_address(module, "DllMain").unwrap();
@@ -37,11 +37,11 @@ mod core {
         }
     }
 
-    process_test! {
+    suspended_process_test! {
         fn get_procedure_address_of_invalid(
             process: OwnedProcess,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.process().wait_for_module_by_name("kernel32.dll", Duration::from_secs(1)).unwrap().unwrap();
             let invalid = syringe.get_procedure_address(module, "ProcedureThatDoesNotExist").unwrap();
             assert!(invalid.is_none());
@@ -59,7 +59,7 @@ mod payload {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_add = unsafe { syringe.get_payload_procedure::<fn(u32, u32) -> u32>(module, "add") }.unwrap().unwrap();
@@ -73,7 +73,7 @@ mod payload {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sum = unsafe { syringe.get_payload_procedure::<fn(Vec<u64>) -> u64>(module, "sum") }.unwrap().unwrap();
@@ -87,7 +87,7 @@ mod payload {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_does_panic = unsafe { syringe.get_payload_procedure::<fn()>(module, "does_panic") }.unwrap().unwrap();
@@ -114,7 +114,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "system" fn(u32, u32) -> u32>(module, "add_raw") }.unwrap().unwrap();
@@ -128,7 +128,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sub = unsafe { syringe.get_raw_procedure::<extern "system" fn(u32, u32) -> u32>(module, "sub_raw") }.unwrap().unwrap();
@@ -142,7 +142,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "system" fn(u16, u8) -> u16>(module, "add_smol_raw") }.unwrap().unwrap();
@@ -156,7 +156,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sum = unsafe { syringe.get_raw_procedure::<extern "system" fn(u32, u32, u32, u32, u32) -> u32>(module, "sum_5_raw") }.unwrap().unwrap();
@@ -170,7 +170,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sum = unsafe { syringe.get_raw_procedure::<extern "system" fn(u32, u32, u32, u32, u32, u32, u32, u32, u32, u32) -> u32>(module, "sum_10_raw") }.unwrap().unwrap();
@@ -184,7 +184,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sub = unsafe { syringe.get_raw_procedure::<extern "system" fn(f32, f32) -> f32>(module, "sub_float_raw") }.unwrap().unwrap();
@@ -198,7 +198,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "C" fn(u32, u32) -> u32>(module, "add_raw_c") }.unwrap().unwrap();
@@ -212,7 +212,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
 
             let remote_sum = unsafe { syringe.get_raw_procedure::<extern "C" fn(u32, u32, u32, u32, u32, u32, u32, u32, u32, u32) -> u32>(module, "sum_10_raw_c") }.unwrap().unwrap();
@@ -226,7 +226,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "C" fn(u32, u32) -> u32>(module, "add_raw_c") }.unwrap().unwrap();
             syringe.eject(module).unwrap();
@@ -240,7 +240,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "C" fn(u32, u32) -> u32>(module, "add_raw_c") }.unwrap().unwrap();
             syringe.process().kill().unwrap();
@@ -254,7 +254,7 @@ mod raw {
             process: OwnedProcess,
             payload_path: &Path,
         ) {
-            let syringe = Syringe::for_process(process);
+            let syringe = Syringe::for_suspended_process(process).unwrap();
             let module = syringe.inject(payload_path).unwrap();
             let remote_add = unsafe { syringe.get_raw_procedure::<extern "C" fn()>(module, "crash") }.unwrap().unwrap();
             let add_err = remote_add.call().unwrap_err();


### PR DESCRIPTION
This PR builds on:
- https://github.com/OpenByteDev/dll-syringe/pull/19

So please address that first, as changes from that PR will show as a diff here otherwise.

---------------

This PR adds support for injecting code into suspended processes.

This is done by adding the API 

```rust
pub fn for_suspended_process(process: OwnedProcess) -> Result<Self, io::Error> 
```

For more details, see the code included, but the tl;dr is; we write a dummy function and execute a thread there; this allows for the process to fully initialize (without starting its main thread); allowing us to then perform operations such as listing modules etc.