### PR TITLE
use inline const expressions instead of MaybeUninit::uninit_array

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(windows)]
-#![feature(maybe_uninit_uninit_array, maybe_uninit_slice, linked_list_cursors)]
+#![feature(maybe_uninit_slice, linked_list_cursors)]
 #![cfg_attr(feature = "syringe", feature(once_cell_try))]
 #![cfg_attr(feature = "rpc-core", feature(min_specialization))]
 #![warn(

--- a/src/syringe.rs
+++ b/src/syringe.rs
@@ -371,7 +371,7 @@ impl Syringe {
         }
 
         let path_len = result as usize;
-        let path = unsafe { MaybeUninit::slice_assume_init_ref(&path_buf[..path_len]) };
+        let path = unsafe { path_buf[..path_len].assume_init_mut() };
         Ok(PathBuf::from(U16Str::from_slice(path).to_os_string()))
     }
 }

--- a/src/syringe.rs
+++ b/src/syringe.rs
@@ -363,7 +363,7 @@ impl Syringe {
 
     #[cfg(all(target_arch = "x86_64", feature = "into-x86-from-x64"))]
     fn wow64_dir() -> Result<PathBuf, io::Error> {
-        let mut path_buf = MaybeUninit::uninit_array::<MAX_PATH>();
+        let mut path_buf = [const { MaybeUninit::uninit() }; MAX_PATH];
         let path_buf_len: u32 = path_buf.len().try_into().unwrap();
         let result = unsafe { GetSystemWow64DirectoryW(path_buf[0].as_mut_ptr(), path_buf_len) };
         if result == 0 {

--- a/src/utils/array_buf.rs
+++ b/src/utils/array_buf.rs
@@ -13,7 +13,7 @@ pub(crate) struct ArrayBuf<T, const SIZE: usize> {
 impl<T, const SIZE: usize> ArrayBuf<T, SIZE> {
     pub fn new_uninit() -> Self {
         Self {
-            data: MaybeUninit::uninit_array(),
+            data: [const { MaybeUninit::uninit() }; SIZE],
             len: 0,
         }
     }

--- a/src/utils/array_buf.rs
+++ b/src/utils/array_buf.rs
@@ -45,11 +45,11 @@ impl<T, const SIZE: usize> ArrayBuf<T, SIZE> {
     }
 
     pub fn as_slice(&self) -> &[T] {
-        unsafe { MaybeUninit::slice_assume_init_ref(&self.data[..self.len]) }
+        unsafe { self.data[..self.len].assume_init_ref() }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.data[..self.len]) }
+        unsafe { self.data[..self.len].assume_init_mut() }
     }
 
     pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {

--- a/src/utils/array_or_vec.rs
+++ b/src/utils/array_or_vec.rs
@@ -134,7 +134,7 @@ impl<T, const SIZE: usize> ArrayOrVecBuf<T, SIZE> {
 impl<const SIZE: usize> ArrayOrVecBuf<u8, SIZE> {
     pub fn spare_writer(&mut self) -> impl std::io::Write + '_ {
         let spare = self.spare_capacity_mut();
-        unsafe { MaybeUninit::slice_assume_init_mut(spare) }
+        unsafe { spare.assume_init_mut() }
     }
 }
 

--- a/src/utils/array_or_vec.rs
+++ b/src/utils/array_or_vec.rs
@@ -28,7 +28,7 @@ impl<T, const SIZE: usize> ArrayOrVecBuf<T, SIZE> {
     }
 
     pub fn new_uninit_array() -> Self {
-        Self::from_partial_init_array(MaybeUninit::uninit_array(), 0)
+        Self::from_partial_init_array([const { MaybeUninit::uninit() }; SIZE], 0)
     }
 
     pub fn from_array(array: [T; SIZE]) -> Self {

--- a/src/utils/win_path_buf_utils.rs
+++ b/src/utils/win_path_buf_utils.rs
@@ -23,8 +23,7 @@ pub fn win_fill_path_buf_helper(
                 vec_buf.resize(buf_len, MaybeUninit::uninit());
                 match f(vec_buf[0].as_mut_ptr(), vec_buf.len()) {
                     FillPathBufResult::Success { actual_len } => {
-                        let slice =
-                            unsafe { MaybeUninit::slice_assume_init_ref(&vec_buf[..actual_len]) };
+                        let slice = unsafe { vec_buf[..actual_len].assume_init_ref() };
                         let wide_str = widestring::U16Str::from_slice(slice);
                         return Ok(wide_str.to_os_string().into());
                     }


### PR DESCRIPTION
`MaybeUninit::uninit_array` has been [removed](https://github.com/rust-lang/rust/pull/125082) because inline const expressions are now stable. This PR addresses that in dll-syringe to allow it to compile again.